### PR TITLE
OpenPOS 2.0.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # OpenPOS changelog
 
+## [2.0.2] - 2024-12-31
+
+### Fixed
+
+- Resolved an issue where a custom products price would not save when adding to cart.
+
 ## [2.0.1] - 2024-12-02
 
 ### Added

--- a/Magewire/AutoAdd.php
+++ b/Magewire/AutoAdd.php
@@ -174,7 +174,7 @@ class AutoAdd extends Component
             }
             $item = $quote->addProduct($product, $request);
 
-            if($this->priceEditorMode) {
+            if($this->priceEditorMode || $this->customProductMode) {
                 $this->customPriceInput = (float)$this->customPriceInput;
                 $item->setCustomPrice($this->customPriceInput);
                 $item->setOriginalCustomPrice($this->customPriceInput);


### PR DESCRIPTION
[2.0.2] - 2024-12-31

**Fixed**
Resolved an issue where a custom products price would not save when adding to cart.