### PR TITLE
Handling multi-word strings in customer search

### DIFF
--- a/Magewire/CustomerManagement.php
+++ b/Magewire/CustomerManagement.php
@@ -144,18 +144,21 @@ class CustomerManagement extends Component
         }
 
         $this->customerSearchResults = [];
-        $searchValue = $this->inputSearch;
+        $searchWords = explode(" ", $this->inputSearch);
 
         // Search email, firstname, lastname
         $customers = $this->customerCollectionFactory->create();
         $customers->addAttributeToSelect('*');
-        $customers->addAttributeToFilter(
-            [
-                ['attribute' => 'email', 'like' => "%$searchValue%"],
-                ['attribute' => 'firstname', 'like' => "%$searchValue%"],
-                ['attribute' => 'lastname', 'like' => "%$searchValue%"],
-            ]
-        );
+
+        foreach($searchWords as $searchWord) {
+            $customers->addAttributeToFilter(
+                [
+                    ['attribute' => 'email', 'like' => "%$searchWord%"],
+                    ['attribute' => 'firstname', 'like' => "%$searchWord%"],
+                    ['attribute' => 'lastname', 'like' => "%$searchWord%"],
+                ]
+            );
+        }
 
         foreach($customers as $customer) {
             $this->customerSearchResults[$customer->getId()] = [


### PR DESCRIPTION
With the following amendment, I can use multiple words in the search term including the following
 - Firstname email@domain.com
 - Lastname email@domain.com
 - Firstname
 - Lastname
 - Firstname Lastname

Single word searches continue to work.