### PR TITLE
OpenPOS 2.1.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,9 @@
 - Improvements to customer search logic.
 - Increased compatible Hyva versions.
 
+### Fixed
+- Resolved an issue where product images would fail to load in the cart.
+
 ## [2.1.1] - 2025-05-06
 
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # OpenPOS changelog
 
-## [2.1.1] - in progress
+## [2.1.1] - 2025-05-06
 
 ### Fixed
 - Resolved an issue where a product search would be performed containing a trailing slash.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,13 @@
 # OpenPOS changelog
 
+## [2.1.2] - in progress
+
+### Added
+- Item options are now visible in the cart.
+
+### Changed
+- Improvements to customer search logic.
+
 ## [2.1.1] - 2025-05-06
 
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # OpenPOS changelog
 
-## [2.1.2] - in progress
+## [2.1.2] - 2025-06-21
 
 ### Added
 - Item options are now visible in the cart.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@
 
 ### Changed
 - Improvements to customer search logic.
+- Increased compatible Hyva versions.
 
 ## [2.1.1] - 2025-05-06
 

--- a/composer.json
+++ b/composer.json
@@ -5,7 +5,7 @@
     ],
     "require": {
         "magento/framework": "^100.1|^101.0|^102.0|^103.0",
-        "zero1/pos-theme": "^2.1",
+        "zero1/pos-theme": "dev-2.1-dev",
         "zero1/pos-pay-card": "^2.0.1",
         "zero1/pos-pay-cash": "^2.0.2",
         "zero1/open-pos-split-payments": "^2.0.1",

--- a/composer.json
+++ b/composer.json
@@ -5,7 +5,7 @@
     ],
     "require": {
         "magento/framework": "^100.1|^101.0|^102.0|^103.0",
-        "zero1/pos-theme": "dev-2.1-dev",
+        "zero1/pos-theme": "^2.1.1",
         "zero1/pos-pay-card": "^2.0.1",
         "zero1/pos-pay-cash": "^2.0.2",
         "zero1/open-pos-split-payments": "^2.0.1",

--- a/view/frontend/templates/html/header/cart.phtml
+++ b/view/frontend/templates/html/header/cart.phtml
@@ -55,20 +55,22 @@ $heroicons = $viewModels->require(HeroiconsOutline::class);
                                             />
                                         </div>
                                         <div class="details w-3/4 p-2">
-                                            <span><?= $item['qty'] ?></span> x <span><?= $item['name'] ?></span>
+                                            <span class="font-bold"><?= $item['qty'] ?></span> x <span class="font-bold"><?= $item['name'] ?></span>
+
+                                            <?php if(!empty($item['options'])): ?>
+                                                <div class="w-full flex flex-wrap">
+                                                    <?php foreach($item['options'] as $option): ?>
+                                                        <div class="w-full">
+                                                            <span><?= $escaper->escapeHtml($option['label']) ?>:</span>
+                                                            <span><?= $escaper->escapeHtml($option['value']) ?></span>
+                                                        </div>
+                                                    <?php endforeach; ?>
+                                                </div>
+                                            <?php endif; ?>
                                             <p><span><?= $item['price'] ?></span></p>
                                         </div>
                                     </div>
-                                    <!-- IN PROGRESS -->
-                                    <?php if(!empty($item['options'])): ?>
-                                        <div>
-                                            <span class="font-bold text-sm"><?= $escaper->escapeHtml(__('Options')) ?></span>
-                                        </div>
-                                        <?php foreach($item['options'] as $option): ?>
-                                            <span><?= $escaper->escapeHtml($option['label']) ?>:</span>
-                                            <span><?= $escaper->escapeHtml($option['value']) ?></span>
-                                        <?php endforeach; ?>
-                                    <?php endif; ?>
+                                   
                                     <div class="actions flex w-full gap-4 p-4">
                                         <button type="button"
                                                 class="inline-flex p-2 btn btn-primary btn-secondary"

--- a/view/frontend/templates/html/header/cart.phtml
+++ b/view/frontend/templates/html/header/cart.phtml
@@ -59,6 +59,16 @@ $heroicons = $viewModels->require(HeroiconsOutline::class);
                                             <p><span><?= $item['price'] ?></span></p>
                                         </div>
                                     </div>
+                                    <!-- IN PROGRESS -->
+                                    <?php if(!empty($item['options'])): ?>
+                                        <div>
+                                            <span class="font-bold text-sm"><?= $escaper->escapeHtml(__('Options')) ?></span>
+                                        </div>
+                                        <?php foreach($item['options'] as $option): ?>
+                                            <span><?= $escaper->escapeHtml($option['label']) ?>:</span>
+                                            <span><?= $escaper->escapeHtml($option['value']) ?></span>
+                                        <?php endforeach; ?>
+                                    <?php endif; ?>
                                     <div class="actions flex w-full gap-4 p-4">
                                         <button type="button"
                                                 class="inline-flex p-2 btn btn-primary btn-secondary"

--- a/view/frontend/templates/html/header/cart.phtml
+++ b/view/frontend/templates/html/header/cart.phtml
@@ -48,7 +48,7 @@ $heroicons = $viewModels->require(HeroiconsOutline::class);
                                     <div class="w-full flex gap-2 px-2 pt-2">
                                         <div class="image w-1/4 p-2">
                                             <img
-                                                src="<?= $item['name'] ?>"
+                                                src="<?= $item['image'] ?>"
                                                 loading="lazy"
                                                 alt=""
                                                 class="w-full"


### PR DESCRIPTION
## [2.1.2] - 2025-06-21

### Added
- Item options are now visible in the cart.

### Changed
- Improvements to customer search logic.
- Increased compatible Hyva versions.

### Fixed
- Resolved an issue where product images would fail to load in the cart.