### PR TITLE
imp: magewirephp/magewire is required

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -5,6 +5,7 @@
     ],
     "require": {
         "magento/framework": "^100.1|^101.0|^102.0|^103.0",
+        "magewirephp/magewire": "*",
         "zero1/pos-theme": "^2.1.1",
         "zero1/pos-pay-card": "^2.0.1",
         "zero1/pos-pay-cash": "^2.0.2",


### PR DESCRIPTION
Magewire is a required package. Requiring in the composer.json will install it also when it's not already installed