### PR TITLE
OpenPOS 2.1.3

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # OpenPOS changelog
 
+## [2.1.3] - in progress
+
+### Fixed
+- RMA items in POS orders no longer deduct product stock.
+- Resolved an issue where out of stock items could not be added regardless of bypass stock configuration.
+
 ## [2.1.2] - 2025-06-21
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,10 @@
 ### Fixed
 - RMA items in POS orders no longer deduct product stock.
 - Resolved an issue where out of stock items could not be added regardless of bypass stock configuration.
+- Resolved an issue where occasionally the first RMA item added to the cart would temporarily display as 0 total.
+
+### Changed
+- Non-RMA payment methods now no longer show on negative quanity carts.
 
 ## [2.1.2] - 2025-06-21
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
 - RMA items in POS orders no longer deduct product stock.
 - Resolved an issue where out of stock items could not be added regardless of bypass stock configuration.
 - Resolved an issue where occasionally the first RMA item added to the cart would temporarily display as 0 total.
+- Resolved category filter layout issues
 
 ### Changed
 - Non-RMA payment methods now no longer show on negative quanity carts.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # OpenPOS changelog
 
-## [2.1.3] - in progress
+## [2.1.3] - 2025-07-11
 
 ### Fixed
 - RMA items in POS orders no longer deduct product stock.

--- a/Plugin/QuantityValidatorBypass.php
+++ b/Plugin/QuantityValidatorBypass.php
@@ -1,0 +1,39 @@
+<?php
+declare(strict_types=1);
+
+namespace Zero1\OpenPos\Plugin;
+
+use Zero1\OpenPos\Helper\Data as OpenPosHelper;
+use Magento\CatalogInventory\Observer\QuantityValidatorObserver;
+use Magento\Framework\Event\Observer;
+
+class QuantityValidatorBypass
+{
+    /**
+     * @var OpenPosHelper
+     */
+    protected $posHelper;
+
+    /**
+     * @param OpenPosHelper $posHelper
+     */
+    public function __construct(
+        OpenPosHelper $posHelper
+    ) {
+        $this->posHelper = $posHelper;
+    }
+
+    /**
+     * @param QuantityValidatorObserver $subject
+     * @param callable $proceed
+     * @param Observer $observer
+     */
+    public function aroundExecute(QuantityValidatorObserver $subject, callable $proceed, Observer $observer): void
+    {
+        if($this->posHelper->currentlyOnPosStore() && $this->posHelper->bypassStock()) {
+            return;
+        }
+
+        $proceed($observer);
+    }
+}

--- a/composer.json
+++ b/composer.json
@@ -9,7 +9,7 @@
         "zero1/pos-pay-card": "^2.0.1",
         "zero1/pos-pay-cash": "^2.0.2",
         "zero1/open-pos-split-payments": "^2.0.1",
-        "zero1/open-pos-rma": "dev-2.1-dev"
+        "zero1/open-pos-rma": "^2.0.2"
     },
     "autoload": {
         "files": [

--- a/composer.json
+++ b/composer.json
@@ -5,7 +5,7 @@
     ],
     "require": {
         "magento/framework": "^100.1|^101.0|^102.0|^103.0",
-        "zero1/pos-theme": "^2.1.1",
+        "zero1/pos-theme": "^2.1.2",
         "zero1/pos-pay-card": "^2.0.1",
         "zero1/pos-pay-cash": "^2.0.2",
         "zero1/open-pos-split-payments": "^2.0.1",

--- a/composer.json
+++ b/composer.json
@@ -9,7 +9,7 @@
         "zero1/pos-pay-card": "^2.0.1",
         "zero1/pos-pay-cash": "^2.0.2",
         "zero1/open-pos-split-payments": "^2.0.1",
-        "zero1/open-pos-rma": "^2.0.1"
+        "zero1/open-pos-rma": "dev-2.1-dev"
     },
     "autoload": {
         "files": [

--- a/etc/di.xml
+++ b/etc/di.xml
@@ -26,6 +26,10 @@
         <plugin name="zero1_openpos_emulate_order_shipping_address" type="Zero1\OpenPos\Plugin\EmulateOrderShippingAddress" sortOrder="10" />
     </type>
 
+    <type name="Magento\CatalogInventory\Observer\QuantityValidatorObserver">
+        <plugin name="zero1_openpos_quantity_validator_bypass" type="Zero1\OpenPos\Plugin\QuantityValidatorBypass"/>
+    </type>
+
     <type name="Zero1\OpenPos\Helper\ModuleIntegration">
         <arguments>
             <argument name="openPosModules" xsi:type="array">


### PR DESCRIPTION
## [2.1.3] - 2025-07-11

### Fixed
- RMA items in POS orders no longer deduct product stock.
- Resolved an issue where out of stock items could not be added regardless of bypass stock configuration.
- Resolved an issue where occasionally the first RMA item added to the cart would temporarily display as 0 total.
- Resolved category filter layout issues

### Changed
- Non-RMA payment methods now no longer show on negative quanity carts.