### PR TITLE
OpenPOS 2.3.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # OpenPOS changelog
 
+## [2.3.1] - 2026-02-05
+
+### Fixed
+- Stock levels not adjusting for POS orders.
+
 ## [2.3.0] - 2026-01-30
 
 ### Added
@@ -10,6 +15,11 @@
 ### Changed
 - Refactor of configuration and logic from old helper classes.
 - Card and cash payment methods moved to a new module: zero1/open-pos-default-payments.
+
+## [2.2.1] - 2026-02-05
+
+### Fixed
+- Stock levels not adjusting for POS orders.
 
 ## [2.2.0] - 2025-11-03
 

--- a/composer.json
+++ b/composer.json
@@ -8,10 +8,10 @@
         "hyva-themes/magento2-default-theme": "^1.4",
         "hyva-themes/magento2-theme-fallback": "^1.0",
         "magewirephp/magewire": "^1.10",
-        "zero1/open-pos-default-theme": "2.2.*",
-        "zero1/open-pos-default-theme-luma": "1.0.*",
-        "zero1/open-pos-default-payments": "1.0.*",
-        "zero1/open-pos-rma": "2.1.*"
+        "zero1/open-pos-default-theme": "2.2.0",
+        "zero1/open-pos-default-theme-luma": "1.0.0",
+        "zero1/open-pos-default-payments": "1.0.0",
+        "zero1/open-pos-rma": "2.1.1"
     },
     "autoload": {
         "files": [


### PR DESCRIPTION
## [2.3.1] - 2026-02-05

### Fixed
- Stock levels not adjusting for POS orders.