### PR TITLE
PHP 8.4 Nullable Deprecation Notice

### DIFF
--- a/Model/PaymentMethod/Layaways.php
+++ b/Model/PaymentMethod/Layaways.php
@@ -67,10 +67,10 @@ class Layaways extends \Magento\Payment\Model\Method\AbstractMethod
         \Magento\Payment\Model\Method\Logger $logger,
         OpenPosConfiguration $openPosConfiguration,
         TillSessionManagement $tillSessionManagement,
-        \Magento\Framework\Model\ResourceModel\AbstractResource $resource = null,
-        \Magento\Framework\Data\Collection\AbstractDb $resourceCollection = null,
+        ?\Magento\Framework\Model\ResourceModel\AbstractResource $resource = null,
+        ?\Magento\Framework\Data\Collection\AbstractDb $resourceCollection = null,
         array $data = [],
-        DirectoryHelper $directory = null
+        ?DirectoryHelper $directory = null
     ) {
         parent::__construct(
             $context,
@@ -93,7 +93,7 @@ class Layaways extends \Magento\Payment\Model\Method\AbstractMethod
      * @param \Magento\Quote\Api\Data\CartInterface|null $quote
      * @return bool
      */
-    public function isAvailable(\Magento\Quote\Api\Data\CartInterface $quote = null)
+    public function isAvailable(?\Magento\Quote\Api\Data\CartInterface $quote = null)
     {
         // Check if POS module is enabled
         if(!$this->openPosConfiguration->isEnabled()) {

--- a/Model/TillSessionManagement.php
+++ b/Model/TillSessionManagement.php
@@ -169,7 +169,7 @@ class TillSessionManagement
      * @param TillSessionInterface|null $tillSession
      * @return bool
      */
-    public function isTillSessionActive(TillSessionInterface $tillSession = null): bool
+    public function isTillSessionActive(?TillSessionInterface $tillSession = null): bool
     {
         if($this->openPosConfiguration->isEnabled() !== true || $this->currentlyOnPosStore() == false) {
             $this->destroySession();
@@ -296,7 +296,7 @@ class TillSessionManagement
      * @param TillSessionInterface|null $tillSession
      * @return User|null
      */
-    public function getAdminUserFromTillSession(TillSessionInterface $tillSession = null): ?User
+    public function getAdminUserFromTillSession(?TillSessionInterface $tillSession = null): ?User
     {
         if(!$tillSession) {
             $tillSession = $this->getTillSession();


### PR DESCRIPTION
* Handles a deprecated nullable warning being thrown in PHP 8.4

Fixes the following error being thrown during checkout on OpenPOS 2.3.1:

> Deprecated: Zero1\OpenPos\Model\PaymentMethod\Layaways::__construct(): Implicitly marking parameter $resource as nullable is deprecated, the explicit nullable type must be used instead in /app/vendor/zero1/open-pos/Model/PaymentMethod/Layaways.php on line 60
Deprecated: Zero1\OpenPos\Model\PaymentMethod\Layaways::__construct(): Implicitly marking parameter $resourceCollection as nullable is deprecated, the explicit nullable type must be used instead in /app/vendor/zero1/open-pos/Model/PaymentMethod/Layaways.php on line 60

Fixes the following warning being thrown during login:

> Deprecated: Zero1\OpenPos\Model\TillSessionManagement::isTillSessionActive(): Implicitly marking parameter $tillSession as nullable is deprecated, the explicit nullable type must be used instead in /app/vendor/zero1/open-pos/Model/TillSessionManagement.php on line 172
Deprecated: Zero1\OpenPos\Model\TillSessionManagement::getAdminUserFromTillSession(): Implicitly marking parameter $tillSession as nullable is deprecated, the explicit nullable type must be used instead in /app/vendor/zero1/open-pos/Model/TillSessionManagement.php on line 299 